### PR TITLE
Added depends_on tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ services:
     image: goofball222/pritunl:latest
     container_name: pritunl
     hostname: pritunl
+    depends_on:
+        - mongo
     network_mode: bridge
     privileged: true
     sysctls:
@@ -90,6 +92,8 @@ services:
     image: goofball222/pritunl:latest
     container_name: pritunl
     hostname: pritunl
+    depends_on:
+        - mongo
     privileged: true
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=0


### PR DESCRIPTION
Changes proposed in this pull request:
- Added depends_on tag to README -> so pritunls startup is halted until mongodb is up and running (just prevents 500 / errors in logs)

@goofball222
