### PR TITLE
Update Dockerfile

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -39,6 +39,7 @@ RUN set -x \
         ip6tables openssl openvpn procps \
         py3-dnspython py3-requests py3-setuptools tzdata \
         wireguard-tools \
+    && apk add --upgrade ipset \    
     && pip3 install --upgrade pip \
     && go get github.com/pritunl/pritunl-dns \
     && go get github.com/pritunl/pritunl-web \


### PR DESCRIPTION
ipset is required otherwise you won't be able to start the VPN server from the PRITUNL web interface

Fixes # .

Changes proposed in this pull request:
- ipset needs to be installed in the alpine pritunl docker container otherwise the vpn server won't start

@goofball222
